### PR TITLE
Selector normalisation

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = (opts = {}) => {
 
   stylesheetsToDiff.forEach(path => {
     postcss.parse(fs.readFileSync(path)).walkRules(rule => {
-      selectors.add(rule.selector)
+      selectors.add(normalizeSelectors(rule))
     })
   });
 
@@ -18,9 +18,11 @@ module.exports = (opts = {}) => {
     postcssPlugin: 'uniquestyles',
 
     Rule(rule) {
+      const selector = normalizeSelectors(rule)
+
       if (
-        selectors.has(rule.selector) ||
-        selectors.has(`[dir=ltr] ${rule.selector}`)
+        selectors.has(selector) ||
+        selectors.has(`[dir=ltr] ${selector}`)
       ) {
         rule.remove()
       }
@@ -29,3 +31,16 @@ module.exports = (opts = {}) => {
 }
 
 module.exports.postcss = true
+
+function normalizeSelectors(rule) {
+  const selectors = Array.from(new Set([...rule.selectors]))
+  selectors.sort()
+
+  return selectors
+    .map(selector => selector
+      .replace(/'/g, '"')
+      .replace(/::(before|after)/g, ':$1')
+      .replace(/\[(.+)=['"]?([a-zA-Z_-]+?)['"]?\]/g, '[$1=$2]')
+    )
+    .join(', ')
+}


### PR DESCRIPTION
This commit adds support for selector normalisation. All selectors read from stylesheets will be formatted using the same rules, so equivalent rules have a higher chance of matching. 

The following samples demonstrate this:

- `h1, h3, h2` -> `h1, h2, h3`
- `*::before, *:after` -> `*:after, *:before`
- `button, [type="submit"], [type=reset], [type='button']` -> `[type=button], [type=reset], [type=submit], button`


### Motivation
In our [Laravel Nova](https://nova.laravel.com) tool, we hit the roadblock this plugin was created to solve. We noticed, however, that some styles were not purged correctly, because the rules in the Nova stylesheet were slightly different from, but functionally equivalent to, the rules in the tool stylesheet.  
This modification properly removes all duplicated rules, even if they're created using a different code style.